### PR TITLE
Modify the axiosWithAuth authorization header and url to fix issues with fetching profile data

### DIFF
--- a/src/utils/axiosWithAuth.js
+++ b/src/utils/axiosWithAuth.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const url =
-  process.env.REACT_APP_API_URL ||
+  process.env.REACT_APP_API_URI ||
   'https://labspt12-express-groomer-f-api.herokuapp.com';
 
 export const axiosWithAuth = () => {

--- a/src/utils/axiosWithAuth.js
+++ b/src/utils/axiosWithAuth.js
@@ -9,7 +9,7 @@ export const axiosWithAuth = () => {
   return axios.create({
     baseURL: url,
     headers: {
-      Authorization: `Bearer ${oktaToken.accessToken.value}`,
+      Authorization: `Bearer ${oktaToken.idToken.value}`,
     },
   });
 };


### PR DESCRIPTION
I made two minor changes to the `axiosWithAuth` function in **utils/axiosWithAuth.js** to fix issues fetching the profile data using the `/profiles` endpoint:

* In the Authorization header, I changed `oktaToken.accessToken.value` to `oktaToken.idToken.value` since we were experiencing difficulties getting the JWT in `accessToken` to validate

* I updated the `url` variable so that it referenced the environment variable for the user's react app URL that most team members are using (probably originating from the env.sample file). This allowed the developers to send API calls to their local API rather than the deployed one

These changes allowed me to fetch data from the `/profiles` and `/profiles/:id` endpoints in the React app.