### PR TITLE
Add Sider(Navbar), Header, and Footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8111,6 +8111,11 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
+    "deep-diff": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -18994,6 +18999,14 @@
       "requires": {
         "lodash": "^4.17.19",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-logger": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
+      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "requires": {
+        "deep-diff": "^0.3.5"
       }
     },
     "redux-thunk": {

--- a/src/components/pages/Nav/ClientNav.js
+++ b/src/components/pages/Nav/ClientNav.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { Layout, Menu, Button, Row, Typography } from 'antd';
+import { useOktaAuth } from '@okta/okta-react';
+
+import './Navbar.css';
+
+import {
+  UserOutlined,
+  HomeOutlined,
+  ClockCircleOutlined,
+  SettingFilled,
+  SearchOutlined,
+} from '@ant-design/icons';
+
+const { SubMenu } = Menu;
+
+function ClientNav(props) {
+  const { Title } = Typography;
+
+  const { authService } = useOktaAuth();
+
+  return (
+    <Layout.Sider
+      className="sidebar"
+      breakpoint={'lg'}
+      collapsedWidth={0}
+      onBreakpoint={broken => {
+        console.log(broken);
+      }}
+      onCollapse={(collapsed, type) => {
+        console.log(collapsed, type);
+      }}
+      style={{
+        height: '100vh',
+      }}
+    >
+      <div className="logo">
+        <Title className="welcome" level={4}>
+          Express Groomers
+        </Title>
+      </div>
+      <Menu
+        theme="dark"
+        onClick={props.handleClick}
+        mode="inline"
+        inlineCollapsed={props.collapsed}
+        defaultSelectedKeys={[`${props.highlight}`]}
+      >
+        <Menu.Item key="1" icon={<HomeOutlined />}>
+          <NavLink to="/" className="nav-text">
+            Home
+          </NavLink>
+        </Menu.Item>
+        <Menu.Item key="2" icon={<SearchOutlined />}>
+          <NavLink to="/search" className="nav-text">
+            Search for Groomers
+          </NavLink>
+        </Menu.Item>
+
+        <SubMenu key="sub1" icon={<UserOutlined />} title="Profile">
+          <Menu.Item key="3">
+            <NavLink to="/profile" className="nav-text">
+              Profile
+            </NavLink>
+          </Menu.Item>
+          <Menu.Item key="4">
+            <NavLink to="/pets" className="nav-text">
+              Pets
+            </NavLink>
+          </Menu.Item>
+          <Menu.Item key="5">
+            <NavLink to="/savedgroomers" className="nav-text">
+              Saved Groomers
+            </NavLink>
+          </Menu.Item>
+        </SubMenu>
+        <Menu.Item key="6" icon={<ClockCircleOutlined />} title="Appointments">
+          <NavLink to="/appointments" className="nav-text">
+            Appointments
+          </NavLink>
+        </Menu.Item>
+        <Menu.Item key="9" icon={<SettingFilled />}>
+          <NavLink to="/settings" className="nav-text">
+            Settings
+          </NavLink>
+        </Menu.Item>
+
+        <Row
+          justify="center"
+          style={{ marginTop: '20px', marginBottom: '20px' }}
+        >
+          <Button
+            ghost
+            onClick={() => authService.logout()}
+            style={{ fontWeight: '400' }}
+          >
+            Logout
+          </Button>
+        </Row>
+      </Menu>
+    </Layout.Sider>
+  );
+}
+
+export default ClientNav;

--- a/src/components/pages/Nav/Footer.js
+++ b/src/components/pages/Nav/Footer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Layout } from 'antd';
+
+function Footer() {
+  const { Footer } = Layout;
+
+  return (
+    <Footer className="footer" style={{ textAlign: 'center' }}>
+      Express Groomer ©2020 Created by Lambda Labs Students
+    </Footer>
+  );
+}
+
+export default Footer;

--- a/src/components/pages/Nav/GroomerNav.js
+++ b/src/components/pages/Nav/GroomerNav.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import { Layout, Menu, Button, Row, Typography } from 'antd';
+import { useOktaAuth } from '@okta/okta-react';
+
+import './Navbar.css';
+
+import {
+  UserOutlined,
+  HomeOutlined,
+  ClockCircleOutlined,
+  SettingFilled,
+} from '@ant-design/icons';
+
+function GroomerNav(props) {
+  const { Title } = Typography;
+
+  const { authService } = useOktaAuth();
+
+  return (
+    <Layout.Sider
+      className="sidebar"
+      breakpoint={'lg'}
+      collapsedWidth={0}
+      height={'200vh'}
+      onBreakpoint={broken => {
+        console.log(broken);
+      }}
+      onCollapse={(collapsed, type) => {
+        console.log(collapsed, type);
+      }}
+      style={{
+        height: '100vh',
+      }}
+    >
+      <div className="logo">
+        <Title className="welcome" level={4}>
+          Express Groomers
+        </Title>
+      </div>
+      <Menu
+        theme="dark"
+        onClick={props.handleClick}
+        mode="inline"
+        inlineCollapsed={props.collapsed}
+        defaultSelectedKeys={[`${props.highlight}`]}
+      >
+        <Menu.Item key="1" icon={<HomeOutlined />}>
+          <NavLink to="/" className="nav-text">
+            Home
+          </NavLink>
+        </Menu.Item>
+        <Menu.Item key="2" icon={<UserOutlined />}>
+          <NavLink to="/profile" className="nav-text">
+            Profile
+          </NavLink>
+        </Menu.Item>
+
+        <Menu.Item key="6" icon={<ClockCircleOutlined />} title="Appointments">
+          <NavLink to="/appointments" className="nav-text">
+            Appointments
+          </NavLink>
+        </Menu.Item>
+        <Menu.Item key="9" icon={<SettingFilled />}>
+          <NavLink to="/settings" className="nav-text">
+            Settings
+          </NavLink>
+        </Menu.Item>
+
+        <Row
+          justify="center"
+          style={{ marginTop: '20px', marginBottom: '20px' }}
+        >
+          <Button
+            ghost
+            onClick={() => authService.logout()}
+            style={{ fontWeight: '400' }}
+            className="logout-button"
+          >
+            Logout
+          </Button>
+        </Row>
+      </Menu>
+    </Layout.Sider>
+  );
+}
+
+export default GroomerNav;

--- a/src/components/pages/Nav/Header.js
+++ b/src/components/pages/Nav/Header.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Layout, Menu, Avatar, Badge } from 'antd';
+import './Header.scss';
+import './Navbar.css';
+
+function Header() {
+  const { Header } = Layout;
+
+  return (
+    <Header className="header">
+      <Menu theme="dark" mode="horizontal">
+        <span className="avatar-item">
+          <Badge
+            size="default"
+            count={2}
+            style={{ backgroundColor: '#a8d5f0' }}
+          >
+            <Avatar
+              className="avatar"
+              size={{ xs: 24, sm: 36, md: 48, lg: 48, xl: 48, xxl: 48 }}
+              src="http://pngimg.com/uploads/dog/dog_PNG50375.png"
+            />
+          </Badge>
+        </span>
+      </Menu>
+    </Header>
+  );
+}
+
+export default Header;

--- a/src/components/pages/Nav/Header.scss
+++ b/src/components/pages/Nav/Header.scss
@@ -1,0 +1,6 @@
+// @import "../../index.scss";
+.header, .avatar-item {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}

--- a/src/components/pages/Nav/Navbar.css
+++ b/src/components/pages/Nav/Navbar.css
@@ -1,0 +1,5 @@
+.logo {
+    height: 32px;
+    background: rgba(255, 255, 255, 0.2);
+    margin: 16px;
+  }

--- a/src/components/pages/Nav/Navbar.js
+++ b/src/components/pages/Nav/Navbar.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import ClientNav from './ClientNav';
+import GroomerNav from './GroomerNav';
+
+class Navbar extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isClient: false,
+    };
+  }
+
+  render() {
+    return this.state.isClient ? (
+      <div>
+        <ClientNav />
+      </div>
+    ) : (
+      <div>
+        <GroomerNav />
+      </div>
+    );
+  }
+}
+
+export default Navbar;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import {
 import { Security, LoginCallback, SecureRoute } from '@okta/okta-react';
 import 'antd/dist/antd.less';
 import './styles/index.scss';
+import { Layout } from 'antd';
 
 import { NotFoundPage } from './components/pages/NotFound';
 import { ExampleListPage } from './components/pages/ExampleList';
@@ -21,6 +22,9 @@ import { ProfileListPage } from './components/pages/ProfileList';
 import { LoginPage } from './components/pages/Login';
 import { config } from './utils/oktaConfig';
 import { LoadingComponent } from './components/common';
+import Navbar from './components/pages/Nav/Navbar';
+import Header from './components/pages/Nav/Header';
+import Footer from './components/pages/Nav/Footer';
 
 ReactDOM.render(
   <Provider store={store}>
@@ -44,22 +48,35 @@ function App() {
     history.push('/login');
   };
 
+  const { Content } = Layout;
+
   return (
     <div className="app-wrapper">
       <Security {...config} onAuthRequired={authHandler}>
         <Switch>
           <Route path="/login" component={LoginPage} />
           <Route path="/implicit/callback" component={LoginCallback} />
-          {/* any of the routes you need secured should be registered as SecureRoutes */}
-          <SecureRoute
-            path="/"
-            exact
-            component={() => <HomePage LoadingComponent={LoadingComponent} />}
-          />
-          <SecureRoute path="/example-list" component={ExampleListPage} />
 
-          <SecureRoute path="/profile-list" component={ProfileListPage} />
-          <Route component={NotFoundPage} />
+          {/* any of the routes you need secured should be registered as SecureRoutes */}
+          <Layout style={{ minHeight: '100vh' }}>
+            <Navbar />
+            <Layout>
+              <Header />
+              <Content style={{ padding: 24, minHeight: 360 }}>
+                <SecureRoute
+                  path="/"
+                  exact
+                  component={() => (
+                    <HomePage LoadingComponent={LoadingComponent} />
+                  )}
+                />
+                <SecureRoute path="/example-list" component={ExampleListPage} />
+
+                <SecureRoute path="/profile-list" component={ProfileListPage} />
+              </Content>
+              <Footer />
+            </Layout>
+          </Layout>
         </Switch>
       </Security>
     </div>


### PR DESCRIPTION
The focus of this PR was to add a navigation sider, header, and footer.

- Added the navigation sider for both client and groomer side that is implemented with conditional rending. The logout button is operational. The sider is responsive. Links are will navigate to pages when implemented. 
- Added header with currently disabled icon with message badge. Icon is responsive.
- Added basic footer.
- Added basic styling necessary to render components of for navigation. 
- Deleted Not Found routing - would not operate within Layout routing. 